### PR TITLE
Allow taking any Read instead of just files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,17 @@
-use anyhow::Result;
 use std::io;
+
+use anyhow::Result;
+
 use zet::args::OpName;
 use zet::operands::first_and_rest;
 use zet::operations::calculate;
+
 fn main() -> Result<()> {
     let args = zet::args::parsed();
 
-    let (first_operand, rest, number_of_operands) = match first_and_rest(&args.files) {
+    let (first_operand, rest, number_of_operands) = match first_and_rest(&args.files)? {
         None => return Ok(()), // No operands implies an empty result
-        Some((first, others, others_len)) => (first?, others, others_len + 1),
+        Some((first, others, others_len)) => (first, others, others_len + 1),
     };
 
     let op = if number_of_operands == 1 && args.op == OpName::Multiple {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
-use std::io;
-
 use anyhow::Result;
+use std::io;
 
 use zet::args::OpName;
 use zet::operands::first_and_rest;

--- a/src/operands.rs
+++ b/src/operands.rs
@@ -3,6 +3,9 @@
 //! operands. *Note:* this different treatment of the first and remaining
 //! operands has the unfortunate result of requiring different code paths for
 //! translating UTF16 files into UTF8. That currently seems worth the cost.
+use anyhow::{Context, Result};
+use bstr::io::BufReadExt;
+use encoding_rs_io::{DecodeReaderBytes, DecodeReaderBytesBuilder};
 use std::{
     fs,
     fs::File,
@@ -10,10 +13,6 @@ use std::{
     ops::FnMut,
     path::{Path, PathBuf},
 };
-
-use anyhow::{Context, Result};
-use bstr::io::BufReadExt;
-use encoding_rs_io::{DecodeReaderBytes, DecodeReaderBytesBuilder};
 
 /// Return the contents of the first file named in `files` as a Vec<u8>, and an iterator over the
 /// subsequent arguments.

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -136,13 +136,9 @@ pub fn calculate<T: Read>(
 #[allow(clippy::pedantic)]
 #[cfg(test)]
 mod test {
-    use std::path::PathBuf;
-
-    use assert_fs::{prelude::*, TempDir};
-
     use super::*;
-
-    use self::OpName::*;
+    use assert_fs::{prelude::*, TempDir};
+    use std::path::PathBuf;
 
     fn calc(operation: OpName, operands: &[&[u8]]) -> String {
         let first = operands[0];
@@ -162,6 +158,8 @@ mod test {
             .unwrap();
         String::from_utf8(answer).unwrap()
     }
+
+    use self::OpName::*;
 
     #[test]
     fn given_a_single_argument_all_ops_but_multiple_return_its_lines_in_order_without_dups() {


### PR DESCRIPTION
This PR is for allowing the `calculate` function to accept any type with an `impl` for `Read` instead of just `File`s. This will allow for faster fuzzing in the future, since `&[u8]`s could be passed directly instead of making files, reading from them, and then deleting them again.

Disclaimer: I am working on [integrating Mayhem into Zet](https://github.com/mayhemheroes/zet/pull/2) for [Mayhem Heroes](https://github.com/mayhemheroes/zet), and if a certain number of tests can be run per second, whoever integrates Mayhem into Zet will get a small amount of money. However, this also seemed like a really cool project and I figured if Zet were to be turned into a library down the line, it'd be useful to let it accept things other than files.