### PR TITLE
Make Operand trait with impl for PathBuf

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,28 +6,16 @@ use zet::operations::calculate;
 fn main() -> Result<()> {
     let args = zet::args::parsed();
 
-    let (first_operand, rest, number_of_operands) = match first_and_rest(&args.files) {
+    let (first_operand, rest) = match first_and_rest(&args.files) {
         None => return Ok(()), // No operands implies an empty result
-        Some((first, others, others_len)) => (first?, others, others_len + 1),
-    };
-
-    let op = if number_of_operands == 1 && args.op == OpName::Multiple {
-        // Since there is only one operand, no line can occur in multiple
-        // operands, so we return at once with an empty result.
-        return Ok(());
-    } else if number_of_operands == 1 {
-        // For a single operand, all operations except Multiple are equivalent
-        // to Union, and Union is slightly more efficient than the others.
-        OpName::Union
-    } else {
-        args.op
+        Some((first, others)) => (first?, others),
     };
 
     let first = first_operand.as_slice();
     if atty::is(atty::Stream::Stdout) {
-        calculate(op, first, rest.as_slice(), io::stdout().lock())?;
+        calculate(args.op, first, &rest, io::stdout().lock())?;
     } else {
-        calculate(op, first, rest.as_slice(), io::BufWriter::new(io::stdout().lock()))?;
+        calculate(args.op, first, &rest, io::BufWriter::new(io::stdout().lock()))?;
     };
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,9 +25,9 @@ fn main() -> Result<()> {
 
     let first = first_operand.as_slice();
     if atty::is(atty::Stream::Stdout) {
-        calculate(op, first, rest, io::stdout().lock())?;
+        calculate(op, first, rest.as_slice(), io::stdout().lock())?;
     } else {
-        calculate(op, first, rest, io::BufWriter::new(io::stdout().lock()))?;
+        calculate(op, first, rest.as_slice(), io::BufWriter::new(io::stdout().lock()))?;
     };
     Ok(())
 }

--- a/src/operands.rs
+++ b/src/operands.rs
@@ -17,7 +17,7 @@ use std::{
 /// Return the contents of the first file named in `files` as a Vec<u8>, and an iterator over the
 /// subsequent arguments.
 #[must_use]
-pub fn first_and_rest(files: &[PathBuf]) -> Option<(Result<Vec<u8>>, Vec<PathBuf>, usize)> {
+pub fn first_and_rest(files: &[PathBuf]) -> Option<(Result<Vec<u8>>, Vec<PathBuf>)> {
     match files {
         [] => None,
         [first, rest @ ..] => {
@@ -25,8 +25,7 @@ pub fn first_and_rest(files: &[PathBuf]) -> Option<(Result<Vec<u8>>, Vec<PathBuf
                 .with_context(|| format!("Can't read file: {}", first.display()))
                 .map(decode_if_utf16);
             let rest = rest.to_vec();
-            let rest_len = rest.len();
-            Some((first_operand, rest, rest_len))
+            Some((first_operand, rest))
         }
     }
 }

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -26,6 +26,18 @@ pub fn calculate<T: Operand>(
     rest: &[T],
     out: impl std::io::Write,
 ) -> Result<()> {
+    let operation = if rest.is_empty() && operation == OpName::Multiple {
+        // Since there is only one operand, no line can occur in multiple
+        // operands, so we return at once with an empty result.
+        return Ok(());
+    } else if rest.is_empty() {
+        // For a single operand, all operations except Multiple are equivalent
+        // to Union, and Union is slightly more efficient than the others.
+        OpName::Union
+    } else {
+        operation
+    };
+
     match operation {
         // `Union` doesn't need bookkeeping, so we use the unit type as its
         // bookkeeping value.


### PR DESCRIPTION
This PR is for allowing `operations::calculate` to accept more types than `File`.

I tried fixing #4 and have it open files one by one, but these changes still have at least one problem. They remove the `Remaining` trait and instead, `calculate` takes a slice of `T`s, where `T: Operand`. If working with files, `T` is `PathBuf`. This means that when iterating over remaining, you immediately get a `PathBuf`, instead of a `Result<NextOperand>` like before, after which you can call `for_byte_line` on the `PathBuf`. So there is no way to differentiate between an error caused by a file that could not be opened and an error caused while reading a file that could be opened. Also, it may be undesirable to have the `for_byte_line` method be directly on `PathBuf` instead of a `struct` defined by zet.

This is a more minor change, but since `Remaining` got replaced by a slice, I moved the code for handling the case when there is only one operand from `main` to `operations::calculate` so that other callers can take advantage of it too. I'm not sure if that's desired either in case the tests want to specifically try out `zet diff` or something on a single operand.

I haven't actually implemented `Operand` for `String` and made the tests use that instead of files because these changes probably need some reworking first. But I'll leave this PR here for now because hopefully it just needs a little working on before it becomes mergeable.