### PR TITLE
Fix -c (should act like --count-lines, was acting like --count-files)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+# [2.0.0 (Unreleased)]
+
+## Fixed
+- `zet -c`, like `zet --count`, is supposed to count the number of times a line appears unless there's a `--files` flag; but due to an error, `-c` always counts the number of files the line appears in. (So if a line appears in one file 100 times, the reported count is 1, even without the `--file` flag.)  This is fixed, but since it changes behaviour in a non-backward compatible way, we bump the version number.
+
 # [1.0.0] - 2023-04-18
 
 ## Added
@@ -57,6 +62,7 @@
 
 Initial release
 
+[2.0.0 (Unreleased)]: https://github.com/yarrow/zet/compare/v1.0.0...back-to-clap
 [1.0.0]: https://github.com/yarrow/zet/compare/v0.2.6...v1.0.0
 [0.2.6]: https://github.com/yarrow/zet/compare/0.2.5...v0.2.6
 [0.2.5]: https://github.com/yarrow/zet/compare/0.2.0...0.2.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "anyhow"
@@ -134,6 +176,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,15 +231,6 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
-
-[[package]]
-name = "enable-ansi-support"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4ff3ae2a9aa54bf7ee0983e59303224de742818c1822d89f07da9856d9bc60"
-dependencies = [
- "windows-sys 0.42.0",
-]
 
 [[package]]
 name = "encoding_rs"
@@ -325,12 +364,6 @@ dependencies = [
  "rustix 0.38.26",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "is_ci"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
 name = "itertools"
@@ -542,16 +575,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "supports-color"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
-dependencies = [
- "is-terminal",
- "is_ci",
-]
-
-[[package]]
 name = "syn"
 version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,6 +644,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,21 +701,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -735,12 +749,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -750,12 +758,6 @@ name = "windows_aarch64_gnullvm"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -771,12 +773,6 @@ checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
@@ -786,12 +782,6 @@ name = "windows_i686_gnu"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -807,12 +797,6 @@ checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
@@ -825,12 +809,6 @@ checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -840,12 +818,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -863,12 +835,13 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 name = "zet"
 version = "2.0.0"
 dependencies = [
+ "anstream",
+ "anstyle",
  "anyhow",
  "assert_cmd",
  "assert_fs",
  "bstr",
  "clap",
- "enable-ansi-support",
  "encoding_rs",
  "encoding_rs_io",
  "fxhash",
@@ -877,7 +850,6 @@ dependencies = [
  "itertools 0.10.5",
  "memchr",
  "once_cell",
- "supports-color",
  "terminal_size",
  "textwrap",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,7 +861,7 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "zet"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zet"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Yarrow Angelweed <yarrow.angelweed@gmail.com>"]
 description = "zet finds the union, intersection, set difference, etc of files considered as sets of lines"
 documentation = "https://github.com/yarrow/zet"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ edition = '2021'
 
 [dependencies]
 anyhow = "1.0.42"
+anstyle = "1.0.4"
+anstream = "0.6.5"
 bstr = { version = "1.1.0", default-features = false, features = ["std", "alloc"] }
 encoding_rs = "0.8.28"
 encoding_rs_io = "0.1.7"
@@ -22,8 +24,6 @@ clap = { version = "4.1.4", default-features = false, features = ["std","error-c
 memchr = "2.4.0"
 indexmap = "1.7.0"
 is-terminal = "0.4.2"
-enable-ansi-support = "0.2.1"
-supports-color = "2.0.0"
 textwrap = "0.16.0"
 once_cell = "1.17.1"
 terminal_size = "0.2.5"

--- a/src/args.rs
+++ b/src/args.rs
@@ -112,7 +112,7 @@ pub enum OpName {
 #[command(name = "zet")]
 /// `CliArgs` contains the parsed command line.
 struct CliArgs {
-    #[arg(short, long, overrides_with_all(["count", "count_files", "count_lines", "count_none"]))]
+    #[arg(long, overrides_with_all(["count", "count_files", "count_lines", "count_none"]))]
     /// The --count-files flag tells `zet` to report the number of files a line occurs in
     count_files: bool,
 
@@ -124,7 +124,7 @@ struct CliArgs {
     /// The --count-none flag tells `zet` to turn off reporting
     count_none: bool,
 
-    #[arg(long, overrides_with_all(["count", "count_files", "count_lines", "count_none"]))]
+    #[arg(short, long, overrides_with_all(["count", "count_files", "count_lines", "count_none"]))]
     /// The --count is like --count-lines, but --files makes it act like --count-files
     count: bool,
 

--- a/src/styles.rs
+++ b/src/styles.rs
@@ -1,57 +1,38 @@
+use anstyle::{AnsiColor, Color, Style};
 use clap::ValueEnum;
-use enable_ansi_support::enable_ansi_support;
-use once_cell::sync::OnceCell;
 use std::fmt;
 
 #[derive(Debug, Clone, ValueEnum)]
-pub enum ColorChoice {
+pub(crate) enum ColorChoice {
     Auto,
     Always,
     Never,
 }
-#[derive(Debug, Clone, Copy)]
-pub struct StyleSheet {
-    app_prefix: Option<&'static str>,
-    item_prefix: Option<&'static str>,
-    title_prefix: Option<&'static str>,
-    error_prefix: Option<&'static str>,
-    literal_prefix: Option<&'static str>,
+const GREEN: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Green)));
+const BOLD_GREEN: Style = GREEN.bold();
+const YELLOW: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Yellow)));
+
+#[must_use]
+pub(crate) fn app_name(content: &str) -> StyledStr {
+    StyledStr { prefix: BOLD_GREEN, content }
 }
-impl StyleSheet {
-    #[must_use]
-    pub fn app_name<'a>(&self, content: &'a str) -> StyledStr<'a> {
-        StyledStr { prefix: self.app_prefix, content }
-    }
-    #[must_use]
-    pub fn item<'a>(&self, content: &'a str) -> StyledStr<'a> {
-        StyledStr { prefix: self.item_prefix, content }
-    }
-    #[must_use]
-    pub fn title<'a>(&self, content: &'a str) -> StyledStr<'a> {
-        StyledStr { prefix: self.title_prefix, content }
-    }
-    #[must_use]
-    pub fn error<'a>(&self, content: &'a str) -> StyledStr<'a> {
-        StyledStr { prefix: self.error_prefix, content }
-    }
-    #[must_use]
-    pub fn literal<'a>(&self, content: &'a str) -> StyledStr<'a> {
-        StyledStr { prefix: self.literal_prefix, content }
-    }
+#[must_use]
+pub(crate) fn as_item(content: &str) -> StyledStr {
+    StyledStr { prefix: GREEN, content }
+}
+#[must_use]
+pub(crate) fn as_title(content: &str) -> StyledStr {
+    StyledStr { prefix: YELLOW, content }
 }
 
-pub struct StyledStr<'a> {
-    prefix: Option<&'static str>,
+pub(crate) struct StyledStr<'a> {
+    prefix: Style,
     content: &'a str,
 }
 impl<'a> StyledStr<'a> {
     #[must_use]
     pub fn len(&self) -> usize {
         self.content.len()
-    }
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.content.is_empty()
     }
     #[must_use]
     pub fn indented_by(&self) -> usize {
@@ -61,64 +42,7 @@ impl<'a> StyledStr<'a> {
 }
 impl<'a> fmt::Display for StyledStr<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(prefix) = self.prefix {
-            write!(f, "{}{}{}", prefix, self.content, RESET)
-        } else {
-            write!(f, "{}", self.content)
-        }
-    }
-}
-
-const BOLD_RED: &str = "\x1B[31;1m";
-const GREEN: &str = "\x1B[32m";
-const BOLD_GREEN: &str = "\x1B[32;1m";
-const YELLOW: &str = "\x1B[33m";
-const RESET: &str = "\x1B[m";
-
-const NEVER: StyleSheet = StyleSheet {
-    app_prefix: None,
-    item_prefix: None,
-    title_prefix: None,
-    error_prefix: None,
-    literal_prefix: None,
-};
-const ALWAYS: StyleSheet = StyleSheet {
-    app_prefix: Some(BOLD_GREEN),
-    item_prefix: Some(GREEN),
-    title_prefix: Some(YELLOW),
-    error_prefix: Some(BOLD_RED),
-    literal_prefix: Some(YELLOW),
-};
-fn auto() -> StyleSheet {
-    use supports_color::Stream;
-    let use_color = enable_ansi_support().is_ok() && supports_color::on(Stream::Stdout).is_some();
-    if use_color {
-        ALWAYS
-    } else {
-        NEVER
-    }
-}
-
-static COLOR_CHOICE: OnceCell<ColorChoice> = OnceCell::new();
-static STYLE_SHEET: OnceCell<StyleSheet> = OnceCell::new();
-pub(crate) fn set_color_choice(cc: ColorChoice) {
-    COLOR_CHOICE.set(cc).expect("set_color_choice may only be called once");
-}
-pub(crate) fn global_style() -> &'static StyleSheet {
-    if let Some(style) = STYLE_SHEET.get() {
-        style
-    } else {
-        let cc = COLOR_CHOICE.get().expect("Please call set_color_choice before calling style");
-        let style = match cc {
-            ColorChoice::Always => {
-                let _ = enable_ansi_support();
-                ALWAYS
-            }
-            ColorChoice::Never => NEVER,
-            ColorChoice::Auto => auto(),
-        };
-        let _ = STYLE_SHEET.set(style); // .set only errors if the value was already set
-        STYLE_SHEET.get().expect("This can't happen: STYLE_SHEET was unset after being set")
+        write!(f, "{}{}{}", self.prefix.render(), self.content, self.prefix.render_reset())
     }
 }
 
@@ -129,10 +53,8 @@ mod test {
     #[test]
     fn test_len() {
         let contents = "abc";
-        for choice in [ALWAYS, NEVER] {
-            assert_eq!(choice.app_name(contents).len(), contents.len());
-            assert_eq!(choice.item(contents).len(), contents.len());
-            assert_eq!(choice.title(contents).len(), contents.len());
-        }
+        assert_eq!(app_name(contents).len(), contents.len());
+        assert_eq!(as_item(contents).len(), contents.len());
+        assert_eq!(as_title(contents).len(), contents.len());
     }
 }


### PR DESCRIPTION
`zet -c`, like `zet --count`, is supposed to count the number of times a line appears unless there's a `--files` flag; but due to an error, `-c` always counts the number of files the line appears in. (So if a line appears in one file 100 times, the reported count is 1, even without the `--file` flag.)  This is fixed, but since it changes behaviour in a non-backward compatible way, we bump the version number.

We also change our color handling under the hood to match `clap`'s